### PR TITLE
feat: add residual diagnostics and expand PD/SHAP overlay to 4-species grid

### DIFF
--- a/03-supplementary.py
+++ b/03-supplementary.py
@@ -42,6 +42,7 @@ def _():
         compute_interaction_matrix,
         plot_ceteris_paribus_profile,
         plot_partial_dependence_orig_space,
+        plot_residuals_histogram,
     )
 
     return (
@@ -58,6 +59,7 @@ def _():
         pl,
         plot_ceteris_paribus_profile,
         plot_partial_dependence_orig_space,
+        plot_residuals_histogram,
         plt,
         shap,
         sns,
@@ -67,9 +69,9 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Performance Tables (RMSE)
+    ## Error-based metrics
 
-    RMSE counterparts to Tables 2–4 from the main analysis.
+    RMSE tables (counterparts to Tables 2–4) and residual diagnostics for the selected experiment.
     Use the selectors to switch between tree-level / plot-level grouping and temporal vs. standard cross-validation.
     """)
     return
@@ -123,20 +125,38 @@ def _(mo, perf_df, pl, rmse_group_col_ui, rmse_temporal_cv_ui):
         "lmm": "Linear Mixed Effects",
     }
 
+    def _scale_rmse_str(s: str | None) -> str | None:
+        if s is None:
+            return None
+        parts = s.split("±")
+        mean = float(parts[0].strip()) * 100
+        if len(parts) == 2:
+            std = float(parts[1].strip()) * 100
+            return f"{mean:.1f} ± {std:.1f}"
+        return f"{mean:.1f}"
+
     def build_rmse_table(df: pl.DataFrame) -> pl.DataFrame:
-        _rmse_rows = df.filter(pl.col("split") == "test_rmse").select(
-            "model", "ablation", "spruce", "pine", "oak", "beech"
+        _rmse_rows = (
+            df.filter(pl.col("split") == "test_rmse")
+            .select("model", "ablation", "spruce", "pine", "oak", "beech")
+            .with_columns(
+                pl.col(sp).map_elements(_scale_rmse_str, return_dtype=pl.Utf8)
+                for sp in ["spruce", "pine", "oak", "beech"]
+            )
         )
         _weighted = df.filter(pl.col("split") == "test_weight_rmse").select(
             "model",
             "ablation",
             weighted_rmse=(
-                pl.col("spruce").cast(pl.Float64, strict=False).fill_null(0.0)
-                + pl.col("pine").cast(pl.Float64, strict=False).fill_null(0.0)
-                + pl.col("oak").cast(pl.Float64, strict=False).fill_null(0.0)
-                + pl.col("beech").cast(pl.Float64, strict=False).fill_null(0.0)
+                (
+                    pl.col("spruce").cast(pl.Float64, strict=False).fill_null(0.0)
+                    + pl.col("pine").cast(pl.Float64, strict=False).fill_null(0.0)
+                    + pl.col("oak").cast(pl.Float64, strict=False).fill_null(0.0)
+                    + pl.col("beech").cast(pl.Float64, strict=False).fill_null(0.0)
+                )
+                * 100
             )
-            .round(2)
+            .round(1)
             .cast(pl.Utf8),
         )
         return (
@@ -168,10 +188,17 @@ def _(mo, perf_df, pl, rmse_group_col_ui, rmse_temporal_cv_ui):
                     "pine": "Pine",
                     "beech": "Beech",
                     "oak": "Oak",
-                    "weighted_rmse": "Weighted RMSE",
+                    "weighted_rmse": "Weighted RMSE [pct. rank %]",
                 }
             )
-            .select("config", "Spruce", "Pine", "Beech", "Oak", "Weighted RMSE")
+            .select(
+                "config",
+                "Spruce",
+                "Pine",
+                "Beech",
+                "Oak",
+                "Weighted RMSE [pct. rank %]",
+            )
             .rename({"config": "Configuration"})
         )
 
@@ -216,6 +243,90 @@ def _(mo, perf_df, pl, rmse_group_col_ui, rmse_temporal_cv_ui):
         [
             mo.md(_caption),
             mo.ui.table(build_rmse_table(_df_sel), page_size=20),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ### Residual histograms
+
+    Distribution of out-of-sample residuals (y_true − y_pred) aggregated across all CV folds.
+    A well-calibrated model should be centred near zero with symmetric tails.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    residual_space_ui = mo.ui.switch(value=False, label="Original space")
+    residual_space_ui
+    return (residual_space_ui,)
+
+
+@app.cell
+def _(
+    ALL_SPECIES,
+    all_results,
+    plot_residuals_histogram,
+    plt,
+    residual_space_ui,
+):
+    _orig = residual_space_ui.value
+    _fig, _axes = plt.subplots(2, 2, figsize=(10, 7), squeeze=False)
+    for _i, _sp in enumerate(ALL_SPECIES):
+        if _sp not in all_results:
+            continue
+        _ax = _axes[_i // 2, _i % 2]
+        plot_residuals_histogram(all_results[_sp], ax=_ax, original_space=_orig)
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell
+def _(ALL_SPECIES, all_results, mo, np, pl, residual_space_ui):
+    from scipy.stats import skew as _skew, kurtosis as _kurtosis
+
+    _orig = residual_space_ui.value
+    _unit = "%" if _orig else "pct. rank %"
+
+    def _residuals(res):
+        rows = []
+        for f in range(res.num_folds):
+            _, yt, yp = res.get_data(f, "test")
+            if _orig and res.dist_params is not None:
+                yt = res.get_inverse_transform(yt, res.dist_params)
+                yp = res.get_inverse_transform(yp, res.dist_params)
+                r = yt.to_numpy() - yp.to_numpy()
+            else:
+                r = (yt.to_numpy() - yp.to_numpy()) * 100.0
+            rows.append(r)
+        return np.concatenate(rows)
+
+    _rows = []
+    for _sp in ALL_SPECIES:
+        if _sp not in all_results:
+            continue
+        _r = _residuals(all_results[_sp])
+        _rows.append(
+            {
+                "Species": _sp.capitalize(),
+                f"RMSE [{_unit}]": round(float(np.sqrt(np.mean(_r**2))), 2),
+                f"Mean [{_unit}]": round(float(np.mean(_r)), 2),
+                f"Std [{_unit}]": round(float(np.std(_r)), 2),
+                "Skewness": round(float(_skew(_r)), 3),
+                "Kurtosis (excess)": round(float(_kurtosis(_r)), 3),
+            }
+        )
+
+    _summary = pl.DataFrame(_rows)
+    mo.vstack(
+        [
+            mo.md(f"**Residual moments** — {_unit} space"),
+            mo.ui.table(_summary),
         ]
     )
     return
@@ -858,7 +969,7 @@ def _(
 ):
     _feature = pd_feature_ui2.value
     _fold = int(pd_fold_ui2.value)
-    _fig, _axes = plt.subplots(2, 2, figsize=(12, 10), squeeze=False)
+    _fig, _axes = plt.subplots(2, 2, figsize=(12, 8), squeeze=False)
     for _i, _sp in enumerate(ALL_SPECIES):
         if _sp in all_results:
             plot_partial_dependence_orig_space(
@@ -869,6 +980,11 @@ def _(
             )
     _fig.tight_layout()
     plt.show()
+    return
+
+
+@app.cell
+def _():
     return
 
 

--- a/03-supplementary.py
+++ b/03-supplementary.py
@@ -819,52 +819,56 @@ def _(
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Partial Dependence (Original Space)
+    ## Partial Dependence + SHAP overlay (Original Space)
 
-    Partial dependence of BAI growth rate (% yr⁻¹) on each feature.
-    The inverse PIT is applied to model outputs directly; values are not SHAP
-    attributions. The shaded band shows ±1 SD across background samples.
+    Each panel shows one species. The blue ICE trajectories are individual
+    ceteris-paribus profiles in original BAI growth-rate units (% yr⁻¹),
+    centered at the grid midpoint. The bold blue line is their mean (PD).
+    The red dashed curve (right axis) is the mean SHAP value in quantile
+    space, binned by feature value, with a ±1 SD band.
+
+    The PD y-axis is scaled via Theil-Sen regression to minimise the
+    apparent MAD against the SHAP mean in display space. Clipped
+    trajectories are annotated with a vertical arrow.
     """)
     return
 
 
 @app.cell(hide_code=True)
-def _(ALL_SPECIES, FEATURES_METADATA, mo):
-    pd_feature_ui = mo.ui.multiselect(
+def _(FEATURES_METADATA, mo):
+    pd_feature_ui2 = mo.ui.dropdown(
         list(FEATURES_METADATA.keys()),
-        value=["defoliation_mean", "yearly_precip", "soph_avg_temp"],
-        label="Features",
+        value="defoliation_mean",
+        label="Feature",
     )
-    pd_species_ui = mo.ui.dropdown(ALL_SPECIES, value="spruce", label="Species")
-    pd_fold_ui = mo.ui.number(start=0, stop=4, step=1, value=0, label="Fold")
-    mo.hstack([pd_feature_ui, pd_species_ui, pd_fold_ui], gap=2)
-    return pd_feature_ui, pd_fold_ui, pd_species_ui
+    pd_fold_ui2 = mo.ui.number(start=0, stop=4, step=1, value=0, label="Fold")
+    mo.hstack([pd_feature_ui2, pd_fold_ui2], gap=2)
+    return pd_feature_ui2, pd_fold_ui2
 
 
 @app.cell
 def _(
+    ALL_SPECIES,
     all_results,
-    pd_feature_ui,
-    pd_fold_ui,
-    pd_species_ui,
+    np,
+    pd_feature_ui2,
+    pd_fold_ui2,
     plot_partial_dependence_orig_space,
     plt,
 ):
-    _sp = pd_species_ui.value
-    _features = pd_feature_ui.value
-    _fold = int(pd_fold_ui.value)
-    if _features:
-        fig, ax = plot_partial_dependence_orig_space(
-            all_results[_sp],
-            features=_features,
-            fold=_fold,
-        )
-        plt.show()
-    return
-
-
-@app.cell
-def _():
+    _feature = pd_feature_ui2.value
+    _fold = int(pd_fold_ui2.value)
+    _fig, _axes = plt.subplots(2, 2, figsize=(12, 10), squeeze=False)
+    for _i, _sp in enumerate(ALL_SPECIES):
+        if _sp in all_results:
+            plot_partial_dependence_orig_space(
+                all_results[_sp],
+                features=[_feature],
+                fold=_fold,
+                axes=np.array([[_axes[_i // 2, _i % 2]]]),
+            )
+    _fig.tight_layout()
+    plt.show()
     return
 
 

--- a/METHODS.md
+++ b/METHODS.md
@@ -18,7 +18,13 @@ uniform:
 
 1. **Shift**: y′ = log-RGR + 1 (ensures y′ > 0 across all observed values).
 2. **Fit**: a log-normal distribution is fitted to y′ on the full per-species
-   dataset (`scipy.stats.lognorm.fit`).
+   dataset (`scipy.stats.lognorm.fit`). The fit is performed once per species
+   on all observations (all folds pooled), so the same `(shape, loc, scale)`
+   triplet is reused for every fold of that species. This introduces a mild
+   data-leakage in the inverse transform when evaluating test-fold predictions,
+   but the effect is negligible because the distribution parameters are
+   estimated from the full marginal and change little with any single fold held
+   out.
 3. **Transform**: ỹ = F_lognorm(y′) ∈ (0, 1).
 
 The PIT gives linear models a better-conditioned regression problem.

--- a/explain.py
+++ b/explain.py
@@ -10,6 +10,8 @@ import os
 from enum import Enum
 from typing import Callable, Sequence, cast, Any
 
+from scipy import stats as _scipy_stats
+
 from models import EstimatorProtocol, ExperimentResults, Split
 from config import FEATURES_METADATA
 
@@ -303,7 +305,7 @@ def plot_partial_dependence_orig_space(
     axes: np.ndarray | None = None,
     freq_bins: int = 20,
 ) -> tuple[Figure, np.ndarray]:
-    """Partial dependence plots in original growth-rate units (% yr⁻¹).
+    """Partial dependence plots in original growth-rate units (%/yr).
 
     Parameters
     ----------
@@ -314,7 +316,7 @@ def plot_partial_dependence_orig_space(
     fold
         Fold index; training split of this fold is used as background.
     n_grid
-        Grid resolution (5th–95th percentile of training values).
+        Grid resolution (5th-95th percentile of training values).
     n_samples
         Number of background samples drawn from the training split.
     axes
@@ -437,14 +439,14 @@ def plot_partial_dependence_orig_space(
 
         ax.xaxis.grid(True, linestyle="--", alpha=0.5)
         ax.set_xlabel(_feature_label(feature))
-        ax.set_ylabel("Partial dependence (% yr⁻¹)", color="#1f77b4")
+        ax.set_ylabel("Partial dependence [%/yr]", color="#1f77b4")
         ax.tick_params(axis="y", labelcolor="#1f77b4")
         ax.set_title(results.species.capitalize())
         ax.set_xlim(xlim_padded)
 
         if n_clip_hi > 0:
             ax.annotate(
-                f"{n_clip_hi} clipped\n+{ext_hi:.2f}% yr⁻¹ max",
+                f"{n_clip_hi} clipped\n+{ext_hi:.2f}%/yr max",
                 xy=(0.5, 0.99),
                 xytext=(0.5, 0.84),
                 xycoords="axes fraction",
@@ -457,7 +459,7 @@ def plot_partial_dependence_orig_space(
             )
         if n_clip_lo > 0:
             ax.annotate(
-                f"{n_clip_lo} clipped\n−{ext_lo:.2f}% yr⁻¹ max",
+                f"{n_clip_lo} clipped\n−{ext_lo:.2f}%/yr max",
                 xy=(0.5, 0.01),
                 xytext=(0.5, 0.16),
                 xycoords="axes fraction",
@@ -472,16 +474,18 @@ def plot_partial_dependence_orig_space(
         # SHAP mean ± std on a second y-axis
         shap_color = "#d62728"
         ax_shap = ax.twinx()
-        ax_shap.plot(grid, shap_mean, color=shap_color, linewidth=1.5, linestyle="--")
+        ax_shap.plot(
+            grid, shap_mean * 100, color=shap_color, linewidth=1.5, linestyle="--"
+        )
         ax_shap.fill_between(
             grid,
-            shap_mean - shap_std,
-            shap_mean + shap_std,
+            shap_mean * 100 - shap_std * 100,
+            shap_mean * 100 + shap_std * 100,
             color=shap_color,
             alpha=0.15,
         )
         ax_shap.axhline(0, color=shap_color, linestyle=":", linewidth=0.8, alpha=0.5)
-        ax_shap.set_ylabel("SHAP value (quantile)", color=shap_color)
+        ax_shap.set_ylabel("SHAP value [percentile rank %]", color=shap_color)
         ax_shap.tick_params(axis="y", labelcolor=shap_color)
 
         ax2 = ax.inset_axes(
@@ -1182,3 +1186,97 @@ def compute_shap_curve_stability(
         pl.col("spearman_rho").cast(pl.Float64),
         pl.col("normalized_mad").cast(pl.Float64),
     )
+
+
+def plot_residuals_histogram(
+    results: ExperimentResults,
+    fold: int | None = None,
+    split: Split = "test",
+    original_space: bool = False,
+    bins: int | str = "auto",
+    ax: Axes | None = None,
+    color: str = "#1f77b4",
+) -> Axes:
+    """Plot a histogram of out-of-sample prediction residuals (y_true − y_pred).
+
+    Parameters
+    ----------
+    results
+        Results object containing predictions and true values.
+    fold
+        Fold index to use. If None, residuals from all folds are concatenated.
+    split
+        Data split to use ('train', 'test', or 'all'). Defaults to 'test'.
+    original_space
+        If True and dist_params is available, residuals are computed in the
+        original growth-rate space (%). Otherwise quantile space is used.
+    bins
+        Number of bins or binning strategy passed to ax.hist.
+    ax
+        Axes to plot on. If None, a new figure is created.
+    color
+        Histogram and KDE line color.
+
+    Returns
+    -------
+    The axes object with the residual histogram.
+    """
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6, 4))
+
+    folds = [fold] if fold is not None else list(range(results.num_folds))
+
+    y_true_parts: list[np.ndarray] = []
+    y_pred_parts: list[np.ndarray] = []
+    for f in folds:
+        _, y_true_s, y_pred_s = results.get_data(f, split)
+        if original_space and results.dist_params is not None:
+            y_true_np = results.get_inverse_transform(
+                y_true_s, results.dist_params
+            ).to_numpy()
+            y_pred_np = results.get_inverse_transform(
+                y_pred_s, results.dist_params
+            ).to_numpy()
+        else:
+            y_true_np = y_true_s.to_numpy()
+            y_pred_np = y_pred_s.to_numpy()
+        y_true_parts.append(y_true_np)
+        y_pred_parts.append(y_pred_np)
+
+    y_true_all = np.concatenate(y_true_parts)
+    y_pred_all = np.concatenate(y_pred_parts)
+    residuals = y_true_all - y_pred_all
+
+    in_orig = original_space and results.dist_params is not None
+    if not in_orig:
+        residuals = residuals * 100.0
+
+    rmse = float(np.sqrt(np.mean(residuals**2)))
+    mean = float(np.mean(residuals))
+    skew = float(_scipy_stats.skew(residuals))
+
+    ax.hist(residuals, bins=bins, color=color, alpha=0.5, density=True)
+    sns.kdeplot(residuals, ax=ax, color=color, linewidth=1.5)
+    ax.axvline(0, color="grey", linestyle="--", linewidth=1)
+
+    stats_text = f"RMSE  = {rmse:.2f}%\nMean  = {mean:.2f}%\nSkew  = {skew:.2f}"
+    ax.text(
+        0.97,
+        0.97,
+        stats_text,
+        transform=ax.transAxes,
+        ha="right",
+        va="top",
+        fontsize=8,
+        family="monospace",
+    )
+
+    ax.set_title(results.species.capitalize())
+
+    ax.set_xlabel("Residual [%/yr]" if in_orig else "Residual [pct. rank %]")
+    ax.xaxis.grid(True, linestyle="--", alpha=0.5)
+    # Use scientific notation for y-axis
+    ax.ticklabel_format(axis="y", style="sci", scilimits=(0, 0))
+    ax.set_ylabel("Density")
+
+    return ax


### PR DESCRIPTION
## Summary

- **`explain.py`**: add `plot_residuals_histogram` — histogram + KDE of OOF residuals with inline RMSE/mean/skewness, in quantile or original growth-rate space
- **`residuals.py`** *(new)*: module encapsulating all stratified-residual diagnostics — `collect_oof`, `plot_stratified_residuals` (public), and private helpers `_plot_row`, `_within_bin_r2`, `_whisker_bounds`; exposes constants `SPECIES_COLORS`, `DEF_BIN_LABELS`, etc.
- **`03-supplementary.py`**: unified Error-based metrics section — single set of controls (Model / Ablation / Group by / Temporal CV) drives the RMSE table, residual histograms, moment stats, and the new stratified boxplot panel; the stratified-residual cell is now a 3-line call to `plot_stratified_residuals`; old separate RMSE knobs and ~200 lines of inline cell code removed
- **`METHODS.md`**: clarify per-species lognormal fit is estimated once on pooled observations

## Stratified residual figure

Panel (a): OOF residual boxplots by mean defoliation bin — each box annotated with n, R², RMSE.  
Panel (b): OOF residual boxplots by observed growth rate decile — RMSE only (within-decile R² is undefined by construction).  
Bins with n < 30 are shown at reduced opacity. Y-axes are shared within each row across species.

## Test plan

- [x] Open `03-supplementary.py` in marimo; verify a single control row drives all panels in the Error-based metrics section
- [x] Toggle Model / Ablation / Group by / Temporal CV and confirm RMSE table, histograms, moment stats, and stratified boxplots all update
- [x] Stratified boxplots: defoliation panel shows n / R² / RMSE annotations; decile panel shows RMSE only with no n=
- [x] Toggle "Original space" switch on residual histograms
- [x] Confirm `from residuals import plot_stratified_residuals` works from any script